### PR TITLE
Add configurable HTTP headers to server connections

### DIFF
--- a/Sources/App/Resources/en.lproj/Localizable.strings
+++ b/Sources/App/Resources/en.lproj/Localizable.strings
@@ -576,6 +576,10 @@ Home Assistant is free and open source home automation software with a focus on 
 "settings.connection_section.errors.cannot_remove_last_url" = "You cannot remove only available URL.";
 "settings.connection_section.external_base_url.placeholder" = "https://homeassistant.myhouse.com";
 "settings.connection_section.external_base_url.title" = "External URL";
+"settings.connection_section.additional_headers.header" = "Additional headers";
+"settings.connection_section.additional_headers.footer" = "Provide HTTP headers to include with requests to this server. Enter one header per line using the format \"Header: Value\".";
+"settings.connection_section.additional_headers.placeholder" = "Header: Value";
+"settings.connection_section.additional_headers.validation_error" = "Headers must be entered in the format \"Header: Value\".";
 "settings.connection_section.header" = "Connection";
 "settings.connection_section.home_assistant_cloud.title" = "Home Assistant Cloud";
 "settings.connection_section.internal_base_url.placeholder" = "e.g. http://homeassistant.local:8123/";

--- a/Sources/App/WebView/WebViewController.swift
+++ b/Sources/App/WebView/WebViewController.swift
@@ -1290,6 +1290,8 @@ extension WebViewController: WebViewControllerProtocol {
 
     func load(request: URLRequest) {
         Current.Log.verbose("Requesting webView navigation to \(String(describing: request.url?.absoluteString))")
+        var request = request
+        server.info.connection.applyAdditionalHTTPHeaders(to: &request)
         webView.load(request)
     }
 

--- a/Sources/Shared/API/Authentication/AuthenticationRoutes.swift
+++ b/Sources/Shared/API/Authentication/AuthenticationRoutes.swift
@@ -4,9 +4,17 @@ import Foundation
 struct RouteInfo: Alamofire.URLRequestConvertible {
     let route: AuthenticationRoute
     let baseURL: URL
+    let additionalHeaders: [String: String]
 
     func asURLRequest() throws -> URLRequest {
-        try route.asURLRequestWith(baseURL: baseURL)
+        var request = try route.asURLRequestWith(baseURL: baseURL)
+
+        for (field, value) in additionalHeaders where
+            request.value(forHTTPHeaderField: field) == nil {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+
+        return request
     }
 }
 

--- a/Sources/Shared/API/Authentication/TokenManager.swift
+++ b/Sources/Shared/API/Authentication/TokenManager.swift
@@ -60,7 +60,8 @@ public class TokenManager {
         return AuthenticationAPI.fetchToken(
             authorizationCode: code,
             baseURL: url,
-            exceptions: connectionInfo.securityExceptions
+            exceptions: connectionInfo.securityExceptions,
+            additionalHeaders: connectionInfo.additionalHTTPHeadersForRequests
         )
     }
 

--- a/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
+++ b/Sources/Shared/API/Webhook/Networking/WebhookManager.swift
@@ -551,6 +551,7 @@ public class WebhookManager: NSObject {
 
             var urlRequest = try URLRequest(url: webhookURL, method: .post)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            server.info.connection.applyAdditionalHTTPHeaders(to: &urlRequest)
 
             let jsonObject = Mapper<WebhookRequest>(context: WebhookRequestContext.server(server)).toJSON(request)
             let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.sortedKeys])

--- a/Sources/Shared/Resources/Swiftgen/Strings.swift
+++ b/Sources/Shared/Resources/Swiftgen/Strings.swift
@@ -2118,6 +2118,16 @@ public enum L10n {
         /// External URL
         public static var title: String { return L10n.tr("Localizable", "settings.connection_section.external_base_url.title") }
       }
+      public enum AdditionalHeaders {
+        /// Additional headers
+        public static var header: String { return L10n.tr("Localizable", "settings.connection_section.additional_headers.header") }
+        /// Provide HTTP headers to include with requests to this server. Enter one header per line using the format “Header: Value”.
+        public static var footer: String { return L10n.tr("Localizable", "settings.connection_section.additional_headers.footer") }
+        /// Header: Value
+        public static var placeholder: String { return L10n.tr("Localizable", "settings.connection_section.additional_headers.placeholder") }
+        /// Headers must be entered in the format “Header: Value”.
+        public static var validationError: String { return L10n.tr("Localizable", "settings.connection_section.additional_headers.validation_error") }
+      }
       public enum HomeAssistantCloud {
         /// Home Assistant Cloud
         public static var title: String { return L10n.tr("Localizable", "settings.connection_section.home_assistant_cloud.title") }

--- a/Tests/Shared/ConnectionInfo.test.swift
+++ b/Tests/Shared/ConnectionInfo.test.swift
@@ -193,6 +193,38 @@ class ConnectionInfoTests: XCTestCase {
         XCTAssertEqual(info.activeAPIURL(), url?.appendingPathComponent("api"))
     }
 
+    func testApplyAdditionalHTTPHeaders() {
+        let url = URL(string: "http://example.com:8123")!
+        var info = ConnectionInfo(
+            externalURL: url,
+            internalURL: nil,
+            cloudhookURL: nil,
+            remoteUIURL: nil,
+            webhookID: "webhook_id1",
+            webhookSecret: nil,
+            internalSSIDs: nil,
+            internalHardwareAddresses: nil,
+            isLocalPushEnabled: false,
+            securityExceptions: .init(),
+            alwaysFallbackToInternalURL: false,
+            httpAdditionalHeaders: [
+                "CF-Access-Client-Id": "id",
+                "CF-Access-Client-Secret": "secret",
+            ]
+        )
+
+        var request = URLRequest(url: url)
+        info.applyAdditionalHTTPHeaders(to: &request)
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "CF-Access-Client-Id"), "id")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "CF-Access-Client-Secret"), "secret")
+
+        request.setValue("existing", forHTTPHeaderField: "CF-Access-Client-Id")
+        info.applyAdditionalHTTPHeaders(to: &request)
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "CF-Access-Client-Id"), "existing")
+    }
+
     func testInternalExternalURL() {
         let internalURL = URL(string: "http://internal.example.com:8123")
         let externalURL = URL(string: "http://external.example.com:8123")


### PR DESCRIPTION
## Summary
- add support for storing sanitized additional HTTP headers on a server connection and apply them across API, webhook, and web view requests
- allow configuring the headers in connection settings with validation and localized strings
- cover the new header handling with unit tests

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68caad9b03d483269efbe1e8a49a7fbc